### PR TITLE
Add option to AdminInviteCommand to send invite email

### DIFF
--- a/app/Console/Commands/AdminInviteCommand.php
+++ b/app/Console/Commands/AdminInviteCommand.php
@@ -2,8 +2,11 @@
 
 namespace App\Console\Commands;
 
+use App\Mail\AdminInviteEmail;
 use Illuminate\Console\Command;
 use App\Models\AdminInvite;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 
 class AdminInviteCommand extends Command
@@ -124,6 +127,12 @@ class AdminInviteCommand extends Command
         $invite->invite_code = Str::uuid() . Str::random(random_int(1,6));
         $invite->save();
 
+        if($this->confirm('Send invitation email to user?')) {
+            $email = $this->promptForEmail();
+
+            Mail::to($email)->send(new AdminInviteEmail($invite));
+        }
+
         $this->info('####################');
         $this->info('# Invite Generated!');
         $this->line(' ');
@@ -175,5 +184,25 @@ class AdminInviteCommand extends Command
         $invite->expires_at = now()->subHours(2);
         $invite->save();
         $this->info('Expired the following invite: ' . $invite->url());
+    }
+
+    protected function promptForEmail(): string
+    {
+        do {
+            $email = $this->ask('What email should the invite be sent to?');
+
+            $validator = Validator::make(
+                ['email' => $email],
+                ['email' => ['required', 'email:rfc,dns']]
+            );
+
+            if ($validator->fails()) {
+                $this->error($validator->errors()->first('email'));
+                $this->newLine();
+                continue;
+            }
+
+            return $email;
+        } while (true);
     }
 }

--- a/app/Mail/AdminInviteEmail.php
+++ b/app/Mail/AdminInviteEmail.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\AdminInvite;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class AdminInviteEmail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly AdminInvite $invite,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: sprintf("You've been invited to join %s!", config('app.name')),
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.user.invite',
+        );
+    }
+}

--- a/resources/views/emails/user/invite.blade.php
+++ b/resources/views/emails/user/invite.blade.php
@@ -1,0 +1,16 @@
+<x-mail::message>
+# You've been invited to join {{ config('app.name') }}!
+
+<x-mail::panel>
+Click the link below to register your account.
+</x-mail::panel>
+
+<x-mail::button :url="$invite->url()">
+Accept Invite
+</x-mail::button>
+
+Thanks,<br>
+{{ config('app.name') }}
+
+<small>This email is automatically generated. Please do not reply to this message.</small>
+</x-mail::message>

--- a/tests/Feature/Commands/AdminInviteCommandTest.php
+++ b/tests/Feature/Commands/AdminInviteCommandTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commands;
+
+use App\Mail\AdminInviteEmail;
+use App\Models\AdminInvite;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AdminInviteCommandTest extends TestCase {
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_creates_invites(): void
+    {
+        Mail::fake();
+
+        $choices = $this->getChoices();
+
+        $this->artisan('admin:invite')
+            ->expectsQuestion('Select an action', $choices['action'])
+            ->expectsQuestion('Invite Name (optional)', $choices['name'])
+            ->expectsQuestion('Invite Description (optional)', $choices['description'])
+            ->expectsQuestion('Invite Message (optional)', $choices['message'])
+            ->expectsQuestion('Max uses', $choices['max_uses'])
+            ->expectsQuestion('Set an invite expiry date?', $choices['expiry_answer'])
+            ->expectsQuestion('Skip email verification', 'Yes')
+            ->expectsConfirmation('Send invitation email to user?', 'no')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('admin_invites', [
+            'name' => $choices['name'],
+            'description' => $choices['description'],
+            'message' => $choices['message'],
+            'max_uses' => $choices['max_uses'],
+            'skip_email_verification' => true,
+        ]);
+
+        $invite = AdminInvite::first();
+        $this->assertNotNull($invite->invite_code);
+        $this->assertTrue($invite->expires_at->isAfter(now()->addHours(23)));
+        $this->assertTrue($invite->expires_at->isBefore(now()->addHours(25)));
+
+        Mail::assertNothingSent();
+    }
+
+    #[Test]
+    public function it_creates_invite_and_sends_email(): void
+    {
+        Mail::fake();
+
+        $choices = $this->getChoices();
+
+        $this->artisan('admin:invite')
+            ->expectsQuestion('Select an action', $choices['action'])
+            ->expectsQuestion('Invite Name (optional)', $choices['name'])
+            ->expectsQuestion('Invite Description (optional)', $choices['description'])
+            ->expectsQuestion('Invite Message (optional)', $choices['message'])
+            ->expectsQuestion('Max uses', $choices['max_uses'])
+            ->expectsQuestion('Set an invite expiry date?', $choices['expiry_answer'])
+            ->expectsQuestion('Skip email verification', 'Yes')
+            ->expectsConfirmation('Send invitation email to user?', 'yes')
+            ->expectsQuestion('What email should the invite be sent to?', $choices['email'])
+            ->assertExitCode(0);
+
+        $this->assertDatabaseCount('admin_invites', 1);
+
+        $invite = AdminInvite::first();
+
+        Mail::assertSent(AdminInviteEmail::class, function (AdminInviteEmail $mail) use ($invite, $choices) {
+            return $mail->hasTo($choices['email']) && $mail->invite->id === $invite->id;
+        });
+    }
+
+    #[Test]
+    public function it_reprompts_for_valid_email_on_validation_failure(): void
+    {
+        Mail::fake();
+
+        $choices = $this->getChoices();
+
+        $this->artisan('admin:invite')
+            ->expectsQuestion('Select an action', $choices['action'])
+            ->expectsQuestion('Invite Name (optional)', $choices['name'])
+            ->expectsQuestion('Invite Description (optional)', $choices['description'])
+            ->expectsQuestion('Invite Message (optional)', $choices['message'])
+            ->expectsQuestion('Max uses', $choices['max_uses'])
+            ->expectsQuestion('Set an invite expiry date?', $choices['expiry_answer'])
+            ->expectsQuestion('Skip email verification', 'Yes')
+            ->expectsConfirmation('Send invitation email to user?', 'yes')
+            ->expectsQuestion('What email should the invite be sent to?', 'invalid-email')
+            ->expectsOutput('The email must be a valid email address.')
+            ->expectsQuestion('What email should the invite be sent to?', 'another@invalid')
+            ->expectsOutput('The email must be a valid email address.')
+            ->expectsQuestion('What email should the invite be sent to?', 'another@example.com')
+            ->expectsOutput('The email must be a valid email address.')
+            ->expectsQuestion('What email should the invite be sent to?', $choices['email'])
+            ->assertExitCode(0);
+
+        $this->assertDatabaseCount('admin_invites', 1);
+
+        Mail::assertSent(AdminInviteEmail::class, function (AdminInviteEmail $mail) use ($choices) {
+            return $mail->hasTo($choices['email']);
+        });
+    }
+
+    protected function getChoices(): array {
+        return [
+            'action' => 'Create invite',
+            'name' => fake()->name(),
+            'description' => fake()->sentence(),
+            'message' => fake()->sentence(),
+            'max_uses' => fake()->numberBetween(1, 10),
+            'expiry_answer' => 'Yes - expire after 24 hours',
+            'email' => fake()->freeEmail(),
+        ];
+    }
+
+}


### PR DESCRIPTION
Inserts a confirmation into the command flow of `admin:invite` to optionally prompt for an email, triggering the `AdminInviteEmail` mailable to be queued.

The email is validated against the usual RFCs (loosely) and a DNS check for MX records.

The new feature test for AdminInviteCommand is very lightweight, solely to confirm this functionality works.